### PR TITLE
Fix 3 URLs in Python 3 book

### DIFF
--- a/book3/08-lists.mkd
+++ b/book3/08-lists.mkd
@@ -820,10 +820,10 @@ of debugging. Here are some common pitfalls and ways to avoid them:
     documentation carefully and then test them in interactive mode. The
     methods and operators that lists share with other sequences (like
     strings) are documented at
-    <https://docs.python.org/2/library/stdtypes.html#string-methods>.
+    <https://docs.python.org/3.5/library/stdtypes.html#common-sequence-operations>.
     The methods and operators that only apply to mutable sequences are
     documented at
-    <https://docs.python.org/2/library/stdtypes.html#mutable-sequence-types>.
+    <https://docs.python.org/3.5/library/stdtypes.html#mutable-sequence-types>.
 
 2.  Pick an idiom and stick with it.
 

--- a/book3/11-regex.mkd
+++ b/book3/11-regex.mkd
@@ -26,7 +26,7 @@ regular expressions, see:
 
 <http://en.wikipedia.org/wiki/Regular_expression>
 
-<https://docs.python.org/2/library/re.html>
+<https://docs.python.org/3.5/library/re.html>
 
 The regular expression library `re` must be imported into
 your program before you can use it. The simplest use of the regular


### PR DESCRIPTION
Link to Python 3 docs instead of Python 2.
Also, a better in-page tag for common sequence operations.