### PR TITLE
Don't shadow built-in function

### DIFF
--- a/book3/02-variables.mkd
+++ b/book3/02-variables.mkd
@@ -438,9 +438,9 @@ resumes and `input` returns what the user typed as a string.
 \index{Python 2.0}
 
 ~~~~ {.python}
->>> input = input()
+>>> inp = input()
 Some silly stuff
->>> print(input)
+>>> print(inp)
 Some silly stuff
 ~~~~
 


### PR DESCRIPTION
I've had a couple people ask me for help with this part because they are following along at the prompt and are mystified when `input()` no longer works.