### PR TITLE
Update where.html

### DIFF
--- a/code3/geodata/where.html
+++ b/code3/geodata/where.html
@@ -7,11 +7,13 @@
 
     <!-- If you are in China, you may need to use theis site for the Google Maps code
     <script src="https://maps.google.cn/maps/api/js" type="text/javascript"></script> -->
-    <!-- Note - you may need your own Google Maps API Key -->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=AIzaSyBZ0IgXbFmVe8IHBB70JOzzbrfcIA9IGl8"></script>
+    
+    <script src="https://maps.googleapis.com/maps/api/js"></script>
 
-
-    <script src="https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js"></script>
+<!-- About MarkerClusterer https://github.com/googlemaps/js-marker-clusterer -->
+<!-- Download markerclusterer.js and /images folder to the geodata directory-->
+    <script src="markerclusterer.js"></script>
+    
     <script src="where.js"></script>
     <script>
 
@@ -39,7 +41,11 @@
                 title: row[2]
             });
             markers.push(marker);
+	    var options = {
+			imagePath: 'images/m'
+			}	
         }
+	var markerCluster = new MarkerClusterer(map, markers, options);
       }
     </script>
   </head>

--- a/code3/geodata/where.html
+++ b/code3/geodata/where.html
@@ -11,8 +11,8 @@
     <script src="https://maps.googleapis.com/maps/api/js"></script>
 
 <!-- About MarkerClusterer https://github.com/googlemaps/js-marker-clusterer -->
-<!-- Download markerclusterer.js and /images folder to the geodata directory-->
-    <script src="markerclusterer.js"></script>
+<!-- Get the raw version of Github script -->
+    <script src="http://rawgit.com/googlemaps/js-marker-clusterer/gh-pages/src/markerclusterer.js"></script>
     
     <script src="where.js"></script>
     <script>
@@ -41,10 +41,12 @@
                 title: row[2]
             });
             markers.push(marker);
+<!-- New options for MarkerClusterer function to display markers -->
 	    var options = {
-			imagePath: 'images/m'
+			imagePath: 'http://rawgit.com/googlemaps/js-marker-clusterer/gh-pages/images/m'
 			}	
         }
+<!-- New var -->
 	var markerCluster = new MarkerClusterer(map, markers, options);
       }
     </script>


### PR DESCRIPTION
As of today 2018.1.14, no API key is needed to call the https://maps.googleapis.com/maps/api/js service.
Regarding the Clusterer library, it has been migrated from the Google Maps JavaScript API utility libraries on Google Code (https://code.google.com/archive/p/google-maps-utility-library-v3/) to Github (https://github.com/googlemaps/js-marker-clusterer). The markerclusterer.js and /images folder need to be downloaded to the geodata directory.  Two new var (var options and var markerCluster) are inserted in the html.