### PR TITLE
Clarify block in interpreter

### DIFF
--- a/book3/01-intro.mkd
+++ b/book3/01-intro.mkd
@@ -244,6 +244,10 @@ that we can even tell it what to say by giving it a message in quotes:
 And we have even written our first syntactically correct Python
 sentence. Our sentence starts with the function *print* 
 followed by a string of text of our choosing enclosed in single quotes.
+The strings in the print statements are enclosed in quotes. Single
+quotes and double quotes do the same thing; most people use single
+quotes except in cases like this where a single quote (which is also an
+apostrophe) appears in the string.
 
 Conversing with Python
 ----------------------

--- a/book3/01-intro.mkd
+++ b/book3/01-intro.mkd
@@ -873,26 +873,26 @@ source code
 Exercises
 ---------
 
-Exercise 1: What is the function of the secondary memory in a computer?
+**Exercise 1: What is the function of the secondary memory in a computer?**
 
 a\) Execute all of the computation and logic of the program\
 b) Retrieve web pages over the Internet\
 c) Store information for the long term, even beyond a power cycle\
 d) Take input from the user
 
-Exercise 2: What is a program?
+**Exercise 2: What is a program?**
 
-Exercise 3: What is the difference between a compiler and an
-interpreter?
+**Exercise 3: What is the difference between a compiler and an
+interpreter?**
 
-Exercise 4: Which of the following contains "machine code"?
+**Exercise 4: Which of the following contains "machine code"?**
 
 a\) The Python interpreter\
 b) The keyboard\
 c) Python source file\
 d) A word processing document
 
-Exercise 5: What is wrong with the following code:
+**Exercise 5: What is wrong with the following code:**
 
 ~~~~ {.python}
     >>> primt 'Hello world!'
@@ -903,8 +903,8 @@ Exercise 5: What is wrong with the following code:
     >>>
 ~~~~
 
-Exercise 6: Where in the computer is a variable such as "x" stored after
-the following Python line finishes?
+**Exercise 6: Where in the computer is a variable such as "x" stored after
+the following Python line finishes?**
 
 ~~~~ {.python}
     x = 123
@@ -916,7 +916,7 @@ c) Secondary Memory\
 d) Input Devices\
 e) Output Devices
 
-Exercise 7: What will the following program print out:
+**Exercise 7: What will the following program print out:**
 
 ~~~~ {.python}
     x = 43
@@ -929,10 +929,10 @@ b) 44\
 c) x + 1\
 d) Error because x = x + 1 is not possible mathematically
 
-Exercise 8: Explain each of the following using an example of a human
+**Exercise 8: Explain each of the following using an example of a human
 capability: (1) Central processing unit, (2) Main Memory, (3) Secondary
 Memory, (4) Input Device, and (5) Output Device. For example, "What is
-the human equivalent to a Central Processing Unit"?
+the human equivalent to a Central Processing Unit"?**
 
-Exercise 9: How do you fix a "Syntax Error"?
+**Exercise 9: How do you fix a "Syntax Error"?**
 

--- a/book3/02-variables.mkd
+++ b/book3/02-variables.mkd
@@ -314,8 +314,8 @@ But in a script, an expression all by itself doesn't do anything! This
 is a common source of confusion for beginners.
 
 
-Exercise 1: Type the following statements in the Python interpreter to
-see what they do:
+**Exercise 1: Type the following statements in the Python interpreter to
+see what they do:**
 
 ~~~~ {.python}
 5
@@ -824,16 +824,16 @@ variable
 Exercises
 ---------
 
-Exercise 2: Write a program that uses `input` to prompt a user for
-their name and then welcomes them.
+**Exercise 2: Write a program that uses `input` to prompt a user for
+their name and then welcomes them.**
 
 ~~~~
 Enter your name: Chuck
 Hello Chuck
 ~~~~
 
-Exercise 3: Write a program to prompt the user for hours and rate per
-hour to compute gross pay.
+**Exercise 3: Write a program to prompt the user for hours and rate per
+hour to compute gross pay.**
 
 ~~~~
 Enter Hours: 35
@@ -846,7 +846,7 @@ the decimal place for now. If you want, you can play with the built-in
 Python `round` function to properly round the resulting pay
 to two decimal places.
 
-Exercise 4: Assume that we execute the following assignment statements:
+**Exercise 4: Assume that we execute the following assignment statements:**
 
 ~~~~
 width = 17
@@ -866,7 +866,7 @@ and the type (of the value of the expression).
 
 Use the Python interpreter to check your answers.
 
-Exercise 5: Write a program which prompts the user for a Celsius
+**Exercise 5: Write a program which prompts the user for a Celsius
 temperature, convert the temperature to Fahrenheit, and print out the
-converted temperature.
+converted temperature.**
 

--- a/book3/02-variables.mkd
+++ b/book3/02-variables.mkd
@@ -422,6 +422,16 @@ linking them end to end. For example:
 
 The output of this program is `100150`.
 
+The `*` operator also works with strings by multiplying the content
+of a string by an integer. For example:
+
+~~~~ {.python}
+>>> first = 'Test '
+>>> second = 3
+>>> print(first * second)
+Test Test Test
+~~~~
+
 Asking the user for input
 -------------------------
 

--- a/book3/03-conditional.mkd
+++ b/book3/03-conditional.mkd
@@ -602,8 +602,8 @@ short circuit
 Exercises
 ---------
 
-Exercise 1: Rewrite your pay computation to give the employee 1.5 times
-the hourly rate for hours worked above 40 hours.
+**Exercise 1: Rewrite your pay computation to give the employee 1.5 times
+the hourly rate for hours worked above 40 hours.**
 
 ~~~~
 Enter Hours: 45
@@ -611,10 +611,10 @@ Enter Rate: 10
 Pay: 475.0
 ~~~~
 
-Exercise 2: Rewrite your pay program using `try` and
+**Exercise 2: Rewrite your pay program using `try` and
 `except` so that your program handles non-numeric input
 gracefully by printing a message and exiting the program. The following
-shows two executions of the program:
+shows two executions of the program:**
 
 ~~~~
 Enter Hours: 20
@@ -627,17 +627,17 @@ Enter Hours: forty
 Error, please enter numeric input
 ~~~~
 
-Exercise 3: Write a program to prompt for a score between 0.0 and 1.0.
+**Exercise 3: Write a program to prompt for a score between 0.0 and 1.0.
 If the score is out of range, print an error message. If the score is
-between 0.0 and 1.0, print a grade using the following table:
+between 0.0 and 1.0, print a grade using the following table:**
 
 ~~~~
-Score   Grade
+ Score   Grade
 >= 0.9     A
 >= 0.8     B
 >= 0.7     C
 >= 0.6     D
-< 0.6    F
+ < 0.6     F
 ~~~~
 
 ~~~~

--- a/book3/03-conditional.mkd
+++ b/book3/03-conditional.mkd
@@ -172,6 +172,21 @@ Small
 >>>
 ~~~~
 
+When using the Python interpreter, you must leave a blank line at the end of a block, otherwise Python will return an error:
+
+~~~~ {.python}
+>>> x = 3
+>>> if x < 10:
+...    print('Small')
+... print('Done')
+  File "<stdin>", line 3
+    print('Done')
+        ^
+SyntaxError: invalid syntax
+~~~~
+
+A blank line at the end of a block of statements is not necessary when writing and executing a script, but it may improve readability of your code.
+
 Alternative execution
 ---------------------
 

--- a/book3/04-functions.mkd
+++ b/book3/04-functions.mkd
@@ -270,8 +270,8 @@ This program produces the following list of 10 random numbers between
 0.028511805472785867
 ~~~~
 
-Exercise 1: Run the program on your system and see what numbers you get.
-Run the program more than once and see what numbers you get.
+**Exercise 1: Run the program on your system and see what numbers you get.
+Run the program more than once and see what numbers you get.**
 
 The `random` function is only one of many functions that
 handle random numbers. The function `randint` takes the
@@ -439,13 +439,13 @@ As you might expect, you have to create a function before you can
 execute it. In other words, the function definition has to be executed
 before the first time it is called.
 
-Exercise 2: Move the last line of this program to the top, so the
+**Exercise 2: Move the last line of this program to the top, so the
 function call appears before the definitions. Run the program and see
-what error message you get.
+what error message you get.**
 
-Exercise 3: Move the function call back to the bottom and move the
+**Exercise 3: Move the function call back to the bottom and move the
 definition of `print_lyrics` after the definition of `repeat_lyrics`.
-What happens when you run this program?
+What happens when you run this program?**
 
 Flow of execution
 -----------------
@@ -798,7 +798,7 @@ void function
 Exercises
 ---------
 
-Exercise 4: What is the purpose of the "def" keyword in Python?
+**Exercise 4: What is the purpose of the "def" keyword in Python?**
 
 a\) It is slang that means "the following code is really cool"\
 b) It indicates the start of a function\
@@ -807,7 +807,7 @@ stored for later\
 d) b and c are both true\
 e) None of the above
 
-Exercise 5: What will the following Python program print out?
+**Exercise 5: What will the following Python program print out?**
 
 ~~~~ {.python}
 def fred():
@@ -827,9 +827,9 @@ c) ABC Zap jane\
 d) ABC Zap ABC\
 e) Zap Zap Zap
 
-Exercise 6: Rewrite your pay computation with time-and-a-half for
+**Exercise 6: Rewrite your pay computation with time-and-a-half for
 overtime and create a function called `computepay` which
-takes two parameters (`hours` and `rate`).
+takes two parameters (`hours` and `rate`).**
 
 ~~~~
 Enter Hours: 45
@@ -837,9 +837,9 @@ Enter Rate: 10
 Pay: 475.0
 ~~~~
 
-Exercise 7: Rewrite the grade program from the previous chapter using a
+**Exercise 7: Rewrite the grade program from the previous chapter using a
 function called `computegrade` that takes a score as its
-parameter and returns a grade as a string.
+parameter and returns a grade as a string.**
 
 ~~~~
 Score   Grade

--- a/book3/04-functions.mkd
+++ b/book3/04-functions.mkd
@@ -128,6 +128,87 @@ Finally, `str` converts its argument to a string:
 '3.14159'
 ~~~~
 
+Math functions
+--------------
+
+\index{math function}
+\index{function, math}
+\index{module}
+\index{module object}
+
+Python has a `math` module that provides most of the familiar
+mathematical functions. Before we can use the module, we have to import
+it:
+
+~~~~ {.python}
+>>> import math
+~~~~
+
+This statement creates a *module object* named math. If
+you print the module object, you get some information about it:
+
+~~~~ {.python}
+>>> print(math)
+<module 'math' (built-in)>
+~~~~
+
+The module object contains the functions and variables defined in the
+module. To access one of the functions, you have to specify the name of
+the module and the name of the function, separated by a dot (also known
+as a period). This format is called *dot notation*.
+
+\index{dot notation}
+
+~~~~ {.python}
+>>> ratio = signal_power / noise_power
+>>> decibels = 10 * math.log10(ratio)
+
+>>> radians = 0.7
+>>> height = math.sin(radians)
+~~~~
+
+The first example computes the logarithm base 10 of the signal-to-noise
+ratio. The math module also provides a function called `log`
+that computes logarithms base `e`.
+
+\index{log function}
+\index{function!log}
+\index{sine function}
+\index{radian}
+\index{trigonometric function}
+\index{function, trigonometric}
+
+The second example finds the sine of `radians`. The name of
+the variable is a hint that `sin` and the other trigonometric
+functions (`cos`, `tan`, etc.) take arguments in
+radians. To convert from degrees to radians, divide by 360 and multiply
+by $2
+\pi$:
+
+~~~~ {.python}
+>>> degrees = 45
+>>> radians = degrees / 360.0 * 2 * math.pi
+>>> math.sin(radians)
+0.7071067811865476
+~~~~
+
+The expression `math.pi` gets the variable `pi`
+from the math module. The value of this variable is an approximation of
+$\pi$, accurate to about 15 digits.
+
+\index{pi}
+
+If you know your trigonometry, you can check the previous result by
+comparing it to the square root of two divided by two:
+
+\index{sqrt function}
+\index{function!sqrt}
+
+~~~~ {.python}
+>>> math.sqrt(2) / 2.0
+0.7071067811865476
+~~~~
+
 Random numbers
 --------------
 
@@ -224,87 +305,6 @@ To choose an element from a sequence at random, you can use
 The `random` module also provides functions to generate
 random values from continuous distributions including Gaussian,
 exponential, gamma, and a few more.
-
-Math functions
---------------
-
-\index{math function}
-\index{function, math}
-\index{module}
-\index{module object}
-
-Python has a `math` module that provides most of the familiar
-mathematical functions. Before we can use the module, we have to import
-it:
-
-~~~~ {.python}
->>> import math
-~~~~
-
-This statement creates a *module object* named math. If
-you print the module object, you get some information about it:
-
-~~~~ {.python}
->>> print(math)
-<module 'math' (built-in)>
-~~~~
-
-The module object contains the functions and variables defined in the
-module. To access one of the functions, you have to specify the name of
-the module and the name of the function, separated by a dot (also known
-as a period). This format is called *dot notation*.
-
-\index{dot notation}
-
-~~~~ {.python}
->>> ratio = signal_power / noise_power
->>> decibels = 10 * math.log10(ratio)
-
->>> radians = 0.7
->>> height = math.sin(radians)
-~~~~
-
-The first example computes the logarithm base 10 of the signal-to-noise
-ratio. The math module also provides a function called `log`
-that computes logarithms base `e`.
-
-\index{log function}
-\index{function!log}
-\index{sine function}
-\index{radian}
-\index{trigonometric function}
-\index{function, trigonometric}
-
-The second example finds the sine of `radians`. The name of
-the variable is a hint that `sin` and the other trigonometric
-functions (`cos`, `tan`, etc.) take arguments in
-radians. To convert from degrees to radians, divide by 360 and multiply
-by $2
-\pi$:
-
-~~~~ {.python}
->>> degrees = 45
->>> radians = degrees / 360.0 * 2 * math.pi
->>> math.sin(radians)
-0.7071067811865476
-~~~~
-
-The expression `math.pi` gets the variable `pi`
-from the math module. The value of this variable is an approximation of
-$\pi$, accurate to about 15 digits.
-
-\index{pi}
-
-If you know your trigonometry, you can check the previous result by
-comparing it to the square root of two divided by two:
-
-\index{sqrt function}
-\index{function!sqrt}
-
-~~~~ {.python}
->>> math.sqrt(2) / 2.0
-0.7071067811865476
-~~~~
 
 Adding new functions
 --------------------

--- a/book3/04-functions.mkd
+++ b/book3/04-functions.mkd
@@ -842,14 +842,13 @@ function called `computegrade` that takes a score as its
 parameter and returns a grade as a string.**
 
 ~~~~
-Score   Grade
-> 0.9     A
-> 0.8     B
-> 0.7     C
-> 0.6     D
-<= 0.6    F
+ Score   Grade
+>= 0.9     A
+>= 0.8     B
+>= 0.7     C
+>= 0.6     D
+ < 0.6     F
 ~~~~
-    Program Execution:
 
 ~~~~
 Enter score: 0.95

--- a/book3/04-functions.mkd
+++ b/book3/04-functions.mkd
@@ -355,11 +355,6 @@ The header has to end with a colon and the body has to be indented. By
 convention, the indentation is always four spaces. The body can contain
 any number of statements.
 
-The strings in the print statements are enclosed in quotes. Single
-quotes and double quotes do the same thing; most people use single
-quotes except in cases like this where a single quote (which is also an
-apostrophe) appears in the string.
-
 \index{ellipses}
 
 If you type a function definition in interactive mode, the interpreter

--- a/book3/05-iterations.mkd
+++ b/book3/05-iterations.mkd
@@ -530,12 +530,12 @@ iteration
 Exercises
 ---------
 
-Exercise 1: Write a program which repeatedly reads numbers until the
+**Exercise 1: Write a program which repeatedly reads numbers until the
 user enters "done". Once "done" is entered, print out the total, count,
 and average of the numbers. If the user enters anything other than a
 number, detect their mistake using `try` and
 `except` and print an error message and skip to the next
-number.
+number.**
 
 ~~~~
 Enter a number: 4
@@ -547,7 +547,7 @@ Enter a number: done
 16 3 5.333333333333333
 ~~~~
 
-Exercise 2: Write another program that prompts for a list of numbers as
+**Exercise 2: Write another program that prompts for a list of numbers as
 above and at the end prints out both the maximum and minimum of the
-numbers instead of the average.
+numbers instead of the average.**
 

--- a/book3/05-iterations.mkd
+++ b/book3/05-iterations.mkd
@@ -88,8 +88,8 @@ statement:
 2.  If the condition is false, exit the `while` statement and
     continue execution at the next statement.
 
-3.  If the condition is true, execute the body and then go back to step
-    1.
+3.  If the condition is true, execute the body and then go back to
+    step 1.
 
 This type of flow is called a *loop* because the third
 step loops back around to the top. We call each time we execute the body

--- a/book3/06-strings.mkd
+++ b/book3/06-strings.mkd
@@ -145,10 +145,10 @@ is false, and the body of the loop is not executed. The last character
 accessed is the one with the index `len(fruit)-1`, which is
 the last character in the string.
 
-Exercise 1: Write a `while` loop that starts at the last
+**Exercise 1: Write a `while` loop that starts at the last
 character in the string and works its way backwards to the first
 character in the string, printing each letter on a separate line, except
-backwards.
+backwards.**
 
 Another way to write a traversal is with a `for` loop:
 
@@ -210,8 +210,8 @@ an *empty string*, represented by two quotation marks:
 An empty string contains no characters and has length 0, but other than
 that, it is the same as any other string.
 
-Exercise 2: Given that `fruit` is a string, what does
-`fruit[:]` mean?
+**Exercise 2: Given that `fruit` is a string, what does
+`fruit[:]` mean?**
 
 \index{copy!slice}
 \index{slice!copy}
@@ -289,8 +289,8 @@ loop exits, `count` contains the result: the total number of
 
 \index{encapsulation}
 
-Exercise 3: Encapsulate this code in a function named `count`, and
-generalize it so that it accepts the string and the letter as arguments.
+**Exercise 3: Encapsulate this code in a function named `count`, and
+generalize it so that it accepts the string and the letter as arguments.**
 
 The `in` operator
 ----------------------------
@@ -502,12 +502,12 @@ can make multiple method calls in a single expression.
 \index{count method}
 \index{method!count}
 
-Exercise 4: There is a string method called `count` that is similar to
+**Exercise 4: There is a string method called `count` that is similar to
 the function in the previous exercise. Read the documentation of this
 method at
 <https://docs.python.org/3.5/library/stdtypes.html#string-methods> and
 write an invocation that counts the number of times the letter a occurs
-in "banana".
+in "banana".**
 
 Parsing strings
 ---------------
@@ -763,27 +763,25 @@ traverse
 Exercises
 ---------
 
-Exercise 5: Take the following Python code that stores a string:\`
+**Exercise 5: Take the following Python code that stores a string:**
 
 `str = 'X-DSPAM-Confidence: `**`0.8475`**`'`
 
-Use `find` and string slicing to extract the portion of the
+**Use `find` and string slicing to extract the portion of the
 string after the colon character and then use the `float`
-function to convert the extracted string into a floating point number.
+function to convert the extracted string into a floating point number.**
 
 \index{string method}
 \index{method!string}
 
-Exercise 6: Read the documentation of the string methods at
-
+**Exercise 6: Read the documentation of the string methods at
 <https://docs.python.org/3.5/library/stdtypes.html#string-methods>
-
 You might want to experiment with some of them to make sure you understand
 how they work. `strip` and `replace` are
-particularly useful.
+particularly useful.**
 
-The documentation uses a syntax that might be confusing. For example, in
+**The documentation uses a syntax that might be confusing. For example, in
 `find(sub[, start[, end]])`, the brackets indicate optional arguments.
 So `sub` is required, but `start` is optional, and
-if you include `start`, then `end` is optional.
+if you include `start`, then `end` is optional.**
 

--- a/book3/06-strings.mkd
+++ b/book3/06-strings.mkd
@@ -45,9 +45,9 @@ of the string, and the offset of the first letter is zero.
 b
 ~~~~
 
-So `b` is the 0th letter ("zero-eth") of "banana",
-`a` is the 1th letter ("one-eth"), and `n` is the
-2th ("two-eth") letter.
+So `b` is the 0th letter ("zero-th") of "banana",
+`a` is the 1th letter ("one-th"), and `n` is the
+2th ("two-th") letter.
 
 ![String Indexes](height=0.75in@../images/string)
 
@@ -139,7 +139,7 @@ while index < len(fruit):
 ~~~~
 
 This loop traverses the string and displays each letter on a line by
-itself. The loop condition is `index \< len(fruit)`, so when
+itself. The loop condition is `index < len(fruit)`, so when
 `index` is equal to the length of the string, the condition
 is false, and the body of the loop is not executed. The last character
 accessed is the one with the index `len(fruit)-1`, which is
@@ -181,8 +181,8 @@ Monty
 Python
 ~~~~
 
-The operator returns the part of the string from the "n-eth" character
-to the "m-eth" character, including the first but excluding the last.
+The operator returns the part of the string from the "n-th" character
+to the "m-th" character, including the first but excluding the last.
 
 If you omit the first index (before the colon), the slice starts at the
 beginning of the string. If you omit the second index, the slice goes to
@@ -287,11 +287,9 @@ to 0 and then incremented each time an `a` is found. When the
 loop exits, `count` contains the result: the total number of
 `a`'s.
 
-Exercise 3:
-
 \index{encapsulation}
 
-Encapsulate this code in a function named `count`, and
+Exercise 3: Encapsulate this code in a function named `count`, and
 generalize it so that it accepts the string and the letter as arguments.
 
 The `in` operator
@@ -501,12 +499,10 @@ use `startswith` to see if the resulting lowercase string
 starts with the letter "h". As long as we are careful with the order, we
 can make multiple method calls in a single expression.
 
-Exercise 4:
-
 \index{count method}
 \index{method!count}
 
-There is a string method called `count` that is similar to
+Exercise 4: There is a string method called `count` that is similar to
 the function in the previous exercise. Read the documentation of this
 method at
 <https://docs.python.org/3.5/library/stdtypes.html#string-methods> and
@@ -775,12 +771,10 @@ Use `find` and string slicing to extract the portion of the
 string after the colon character and then use the `float`
 function to convert the extracted string into a floating point number.
 
-Exercise 6:
-
 \index{string method}
 \index{method!string}
 
-Read the documentation of the string methods at
+Exercise 6: Read the documentation of the string methods at
 
 <https://docs.python.org/3.5/library/stdtypes.html#string-methods>
 


### PR DESCRIPTION
Add instruction and example to chapter 3 that explains to leave
a blank line after a command block when using Python interpreter.