### PR TITLE
Update where.html

### DIFF
--- a/code3/geodata/where.html
+++ b/code3/geodata/where.html
@@ -11,7 +11,6 @@
     <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&key=AIzaSyBZ0IgXbFmVe8IHBB70JOzzbrfcIA9IGl8"></script>
 
 
-    <script src="https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclusterer/src/markerclusterer_compiled.js"></script>
     <script src="where.js"></script>
     <script>
 


### PR DESCRIPTION
Remove markercluster URL as it's a 404 Not Found, comments in discussions it's an error in the JavaScript console. The code has different URLs for different versions, it also moved from Google code, to a GitHub repo. Removed from where.html and tested works fine.