### PR TITLE
Update gline.py

### DIFF
--- a/code3/gmane/gline.py
+++ b/code3/gmane/gline.py
@@ -50,7 +50,7 @@ months.sort()
 # print months
 
 fhand = open('gline.js','w')
-fhand.write("gline = [ ['Year'")
+fhand.write("gline = [ ['Month'")
 for org in orgs:
     fhand.write(",'"+org+"'")
 fhand.write("]")


### PR DESCRIPTION
Follow up student feedback, although only visible in gline.js output file, the book example and run default code flow - gmane gmodel gbasic gword gline  -> gline.js gline.htm is by default a monthly graph. While gyear.py does write 'Year'