### PR TITLE
Update 08-lists.mkd

### DIFF
--- a/book3/08-lists.mkd
+++ b/book3/08-lists.mkd
@@ -1017,7 +1017,7 @@ file.
 
 Exercise 3: Rewrite the guardian code in the above example without
 two `if` statements. Instead, use a compound logical
-expression using the `and` logical operator with a single
+expression using the `or` logical operator with a single
 `if` statement.
 
 Glossary


### PR DESCRIPTION
It should be `or` in the example, It should not be `and`

something like this:

```python
fhand = open('mbox.txt')
for line in fhand:
  words = line.split()
  if len(words) == 0 or words[0] != 'From' : continue
  print(words[2])
```