### PR TITLE
Update gmodel.py

### DIFF
--- a/code3/gmane/gmodel.py
+++ b/code3/gmane/gmodel.py
@@ -56,7 +56,7 @@ def fixsender(sender,allsenders=None) :
 def parsemaildate(md) :
     # See if we have dateutil
     try:
-        pdate = parser.parse(tdate)
+        pdate = parser.parse(md)
         test_at = pdate.isoformat()
         return test_at
     except:


### PR DESCRIPTION
Update argument used within function to be the same as the outer parsemaildate() parameter. Causes problem for some students, the email date is the same for every message.