### PR TITLE
Update json2.py

### DIFF
--- a/code3/json2.py
+++ b/code3/json2.py
@@ -8,7 +8,7 @@ data = '''
   } ,
   { "id" : "009",
     "x" : "7",
-    "name" : "Chuck"
+    "name" : "Brent"
   }
 ]'''
 


### PR DESCRIPTION
Student report. Chapter 13 of the book, https://py4e.com/html3/13-web the data in the example code is Chuck / Chuck (matches the lecture) but as the book says "The output of this program is exactly the same as the XML version above." to do that json2.py needs edited so the XML / JSON examples match.

The lecture 13.5 - JavaScript Object Notation (JSON) from 07:27 doesn't show the output so it's less of a problem.

The 2nd lecture "Worked Example: JSON (Chapter 13)" now won't match @ 04:54

But the XML lecture, worked example, book still all match. 

This is the smallest change to make the 2 examples the same, but now won't match Chuck / Chuck. in the lecture, but matches both example outputs in the book, and xml2.py.

I think it's better to change json2.py to keep the point in the book, that they both have the same output.