### PR TITLE
typo: changed "<\person>" to "</person>"

### DIFF
--- a/book3/13-web.mkd
+++ b/book3/13-web.mkd
@@ -31,7 +31,7 @@ Here is a sample of an XML document:
 ~~~~
 
 Each pair of opening (e.g., `<person>`) and closing tags
-(e.g., `<\person>`) represents a *element* or *node* with the same
+(e.g., `</person>`) represents a *element* or *node* with the same
 name as the tag (e.g., `person`). Each element can have some text,
 some attributes (e.g., `hide`), and other nested elements. If an XML
 element is empty (i.e., has no content), then it may be depicted by


### PR DESCRIPTION
I'm not sure if github needs slash escaping, so perhaps my edit itself is bad.
Before my edit, the text quoted an XML closing tag as "<\person>" which is clearly the wrong slash.
I'm intending to change it to "</person>" to reflect the context.