### PR TITLE
Changed filenames xx.sqlite3 to xx.sqlite

### DIFF
--- a/book3/15-database.mkd
+++ b/book3/15-database.mkd
@@ -112,7 +112,7 @@ with two columns in the database is as follows:
 \index{function!cursor}
 
 The `connect` operation makes a "connection" to the database
-stored in the file `music.sqlite3` in the current directory.
+stored in the file `music.sqlite` in the current directory.
 If the file does not exist, it will be created. The reason this is
 called a "connection" is that sometimes the database is stored on a
 separate "database server" from the server on which we are running our
@@ -347,7 +347,7 @@ Here is the source code for our Twitter spidering application:
 
 \VerbatimInput{../code3/twspider.py}
 
-Our database is stored in the file `spider.sqlite3` and it
+Our database is stored in the file `spider.sqlite` and it
 has one table named `Twitter`. Each row in the
 `Twitter` table has a column for the account name, whether we
 have retrieved the friends of this account, and how many times this
@@ -429,13 +429,13 @@ Enter a Twitter account, or quit: quit
 ~~~~
 
 Since this is the first time we have run the program, the database is
-empty and we create the database in the file `spider.sqlite3`
+empty and we create the database in the file `spider.sqlite`
 and add a table named `Twitter` to the database. Then we
 retrieve some friends and add them all to the database since the
 database is empty.
 
 At this point, we might want to write a simple database dumper to take a
-look at what is in our `spider.sqlite3` file:
+look at what is in our `spider.sqlite` file:
 
 \VerbatimInput{../code3/twdump.py}
 


### PR DESCRIPTION
There was 1 reference to "music.sqlite3" as a file and 3 to "spider.sqlite3."
On my linux system and in online videos of another system, the actual files are
music.sqlite and spider.sqlite.
I've changed the filenames to reflect what I think is correct.
I suspect this is a revision issue.

Thank you for the wonderful textbook. I found it very easy and informative.