### PR TITLE
Fix for med / low res displays

### DIFF
--- a/code3/gmane/gline.htm
+++ b/code3/gmane/gline.htm
@@ -9,7 +9,8 @@
         var data = google.visualization.arrayToDataTable( gline );
 
         var options = {
-          title: 'Sakai Developer Email Participation by Organization'
+          title: 'Sakai Developer Email Participation by Organization',
+          chartArea: {left:'10%',top:'10%', width: '65%', height: '65%'}
         };
 
         var chart = new google.visualization.LineChart(document.getElementById('chart_div'));
@@ -18,6 +19,6 @@
     </script>
   </head>
   <body>
-    <div id="chart_div" style="width: 1400px; height: 800px;"></div>
+    <div id="chart_div" style="width: 1300px; height: 600px;"></div>
   </body>
 </html>


### PR DESCRIPTION
For many systems with res 1440x900 / 1366x768, the original chart div 1400x800 means page needs scrolled, or browser page zoom as it doesn't fit browser window. Fix - use the API ChartArea options, position and size chart, within a smaller div 1300x600.

Without autodetect resolutions, it's not a 1 fix for all, as 2000+ / 3000+ rez screens the graph is smaller in any case. These changes means it works for more people without scrolling page, using browser zoom, or ignoring the legend, x-axis, lines below 50 are missing.

I've tested on an Ubuntu virtual machine as it's easy to resize display, it's all good at
1280x800
1366x768
1440x900
1600x900
1680x1050 (although this is my remote desktop, the VM frame uses some pixels for it's toolbar, but the graph fits)
1920x1200
and the physical laptop 1920x1080
going smaller, 
1152x864 expected an issue, but scroll browser, page zoom still works here.

Sent email with screenshots as examples.