### PR TITLE
Update urllink2.py remove install BSoup references

### DIFF
--- a/code3/urllink2.py
+++ b/code3/urllink2.py
@@ -1,7 +1,4 @@
-# To run this, you can install BeautifulSoup
-# https://pypi.python.org/pypi/beautifulsoup4
-
-# Or download the file
+# To run this, download the BeautifulSoup zip file
 # http://www.py4e.com/code3/bs4.zip
 # and unzip it in the same directory as this file
 


### PR DESCRIPTION
Catch up change, references to pypi have been removed from the student page.
Coursera pages, thread
https://www.coursera.org/learn/python-network-data/discussions/all/threads/ZvrDAb4DEem92Qo07xTPdA