### PR TITLE
added context=ctx parameter for use with https

### DIFF
--- a/code3/urlregex.py
+++ b/code3/urlregex.py
@@ -9,7 +9,7 @@ ctx.check_hostname = False
 ctx.verify_mode = ssl.CERT_NONE
 
 url = input('Enter - ')
-html = urllib.request.urlopen(url).read()
+html = urllib.request.urlopen(url, context=ctx).read()
 links = re.findall(b'href="(http[s]?://.*?)"', html)
 for link in links:
     print(link.decode())


### PR DESCRIPTION
The ctx that accounts for handling https sites had been defined in previous lines but not used. 
This change is in line with the parameters passed to urllib.request.urlopen() that account for both http and https sites, as defined in the lecture videos and other sample files provided by Dr. Chuck.