### PR TITLE
Update 03-conditional.mkd empty formatting code left over?

### DIFF
--- a/book3/03-conditional.mkd
+++ b/book3/03-conditional.mkd
@@ -19,7 +19,6 @@ equal and `False` otherwise:
 True
 >>> 5 == 6
 False
-{}
 ~~~~
 
 `True` and `False` are special values that belong


### PR DESCRIPTION
Left over formatting code, an {}. Remove as it's not part of the actual output.
Student comment in FL session 4 -
In the HTML book chapter 3, under the title "Boolean expressions" there is a statement:
>>> 5 == 6
When I try above statement with the python3 interpreter, I don't get the the line with "{}" as in the HTML book.