### PR TITLE
account name check in the database

### DIFF
--- a/code3/twspider.py
+++ b/code3/twspider.py
@@ -41,7 +41,11 @@ while True:
     # Debugging
     # print json.dumps(js, indent=4)
 
-    cur.execute('UPDATE Twitter SET retrieved=1 WHERE name = ?', (acct, ))
+    name_in_database = cur.execute('SELECT name FROM Twitter WHERE name = ? LIMIT 1', (acct,)).fetchone()
+    if name_in_database is None:
+        cur.execute('INSERT OR IGNORE INTO Twitter (name, retrieved, friends) VALUES (?, 1, 0)', (acct,))
+    else:
+        cur.execute('UPDATE Twitter SET retrieved=1 WHERE name = ?', (acct,))
 
     countnew = 0
     countold = 0


### PR DESCRIPTION
Hi Dr. Chuck, 
I noticed that if an account name is taken from user input and it's not in the database, then it cannot be updated to set "retrieved"=1. So if it's eventually inserted in the database as a follower of another user, this entry will have "retrieved"=0 and the code can be executed again for the same account name. I suggest to check if the account name is in the database and insert it if it's not there.