### PR TITLE
Fixed markdown to put in bold Exercise 4 in Chapter 6

### DIFF
--- a/book3/06-strings.mkd
+++ b/book3/06-strings.mkd
@@ -504,11 +504,11 @@ can make multiple method calls in a single expression.
 
 **Exercise 4: There is a string method called `count` that is similar to
 the function in the previous exercise. Read the documentation of this
-method at:
+method at:**
 
 <https://docs.python.org/library/stdtypes.html#string-methods> 
 
-Write an invocation that counts the number of times the letter a occurs
+**Write an invocation that counts the number of times the letter a occurs
 in "banana".**
 
 Parsing strings


### PR DESCRIPTION
Every exercise in the book is in bold. Due to the url included in Exercise 4, Chapter 6 markdown format was broken. Fixed it by adding two **.

> -method at:
> +method at:**
> 
> <https://docs.python.org/library/stdtypes.html#string-methods> 
> 
> -Write an invocation that counts the number of times the letter a occurs
> +**Write an invocation that counts the number of times the letter a occurs