### PR TITLE
Student report in FutureLearn Data Structures

### DIFF
--- a/book3/11-regex.mkd
+++ b/book3/11-regex.mkd
@@ -200,19 +200,20 @@ simply check if the number of elements in our returned list is more than
 zero to print only lines where we found at least one substring that
 looks like an email address.
 
-If we run the program on *mbox.txt* we get the following
+If we run the program on *mbox-short.txt* we get the following
 output:
 
 ~~~~
-['wagnermr@iupui.edu']
-['cwen@iupui.edu']
-['<postmaster@collab.sakaiproject.org>']
-['<200801032122.m03LMFo4005148@nakamura.uits.iupui.edu>']
-['<source@collab.sakaiproject.org>;']
+...
 ['<source@collab.sakaiproject.org>;']
 ['<source@collab.sakaiproject.org>;']
 ['apache@localhost)']
 ['source@collab.sakaiproject.org;']
+['cwen@iupui.edu']
+['source@collab.sakaiproject.org']
+['cwen@iupui.edu']
+['cwen@iupui.edu']
+['wagnermr@iupui.edu']
 ~~~~
 
 Some of our email addresses have incorrect characters like "<" or ";"
@@ -319,6 +320,7 @@ X-DSPAM-Confidence: 0.8475
 X-DSPAM-Probability: 0.0000
 X-DSPAM-Confidence: 0.6178
 X-DSPAM-Probability: 0.0000
+...
 ~~~~
 
 But now we have to solve the problem of extracting the numbers. While it
@@ -359,7 +361,7 @@ The output from this program is as follows:
 ['0.0000']
 ['0.6961']
 ['0.0000']
-..
+...
 ~~~~
 
 The numbers are still in a list and need to be converted from strings to


### PR DESCRIPTION
Continuing with book, some issues. Continuation ... markers to indicate more output.
203 output is for mbox-short, not mbox. 
207 new ...
208-216 update last 9 lines for code run 4/8/21 new downloads of re05-re11.py and mbox, mbox-short.
323 new ...
364 amend .. to ... match other new / existing lines

re07.py code also needs fixed to match text lines 230/233 - our new regular expression. However the output is no different, both regex run on mbox-short and output checked with file comparison shows no differences. As long as the address is good, the (rfc822) no whitespace between words separated by a "." or an "@" sign. re07.py run on mbox.txt both regex also no differences in output. Double checked by comparing the 2 re07.pyre07fix.py tests only difference is
x = re.findall('[a-zA-Z0-9]\S+@\S+[a-zA-Z]', line)
x = re.findall('[a-zA-Z0-9]\S*@\S*[a-zA-Z]', line)