### PR TITLE
Add list comprehension to Chapter 10

### DIFF
--- a/book3/10-tuples.mkd
+++ b/book3/10-tuples.mkd
@@ -545,6 +545,33 @@ a new sequence with the same elements in a different order.
 \index{reversed function}
 \index{function!reversed}
 
+List comprehension
+------------------
+
+Sometimes you want to create a sequence by using data from another sequence.
+You can achieve this by writing a for loop and appending one item at a time.
+For example, if you wanted to convert a list of strings -- each string storing digits
+-- into numbers that you can sum up, you would write:
+
+~~~~ {.python}
+list_of_ints_in_strings = ['42', '65', '12']
+list_of_ints = []
+for x in list_of_ints_in_strings:
+    list_of_ints.append(int(x))
+
+print(sum(list_of_ints))
+~~~~
+
+With list comprehension, the above code can be written in a more compact manner:
+
+~~~~ {.python}
+list_of_ints_in_strings = ['42', '65', '12']
+list_of_ints = [ int(x) for x in list_of_ints_in_strings ]
+print(sum(list_of_ints))
+~~~~
+
+\index{list comprehension}
+
 Debugging
 ---------
 


### PR DESCRIPTION
The regex assignment, specifically the "just for fun" part, mentions:

>  List comprehension is mentioned in Chapter 10

However, I found no list comprehension in Chapter 10.

This patch adds list comprehension to Chapter 10.