### PR TITLE
Update 04-functions.mkd

### DIFF
--- a/book3/04-functions.mkd
+++ b/book3/04-functions.mkd
@@ -821,11 +821,23 @@ fred()
 jane()
 ~~~~
 
-a\) Zap ABC jane fred jane\
-b) Zap ABC Zap\
-c) ABC Zap jane\
-d) ABC Zap ABC\
-e) Zap Zap Zap
+a\) Zap\
+ABC\
+jane\
+fred\
+jane\
+b) Zap\
+ABC\
+Zap\
+c) ABC\
+Zap\
+jane\
+d) ABC\
+Zap\
+ABC\
+e) Zap\
+Zap\
+Zap
 
 **Exercise 6: Rewrite your pay computation with time-and-a-half for
 overtime and create a function called `computepay` which


### PR DESCRIPTION
Adds linebreaks to the solutions for Exercise 5.

In the published version, the "correct" solution is a bit incorrect, due to missing linebreaks. (There are other ways to fix this!)

.