### PR TITLE
Bug line 677 string.:

### DIFF
--- a/book3/06-strings.mkd
+++ b/book3/06-strings.mkd
@@ -674,7 +674,7 @@ if line.startswith('#'):
 Another way is to safely write the `if` statement using the
 *guardian* pattern and make sure the second logical
 expression is evaluated only where there is at least one character in
-the string.:
+the string:
 
 ~~~~ {.python}
 if len(line) > 0 and line[0] == '#':


### PR DESCRIPTION
At times, before an example, you tend to use a colon, a few times, like in line 485, 'method.', you use a period, same in like 473 after 'values' before the example is a period as well, not sure if those are on purpose.  However, I have never seen a period and a colon like in line 677 after 'string', so I propose the change to, 'string' with a colon after 'string:'
I have left alone the times a period is used before the example, unless that is also a bug, then there are a few more examples of those I noticed.  If those are bugs, I can identify and fix them, if not, then just removing the period.