### PR TITLE
Change Tab & Shift-Tab behaviour in codemirror.js

### DIFF
--- a/tools/pythonauto/static/codemirror/codemirror.js
+++ b/tools/pythonauto/static/codemirror/codemirror.js
@@ -3646,7 +3646,7 @@ window.CodeMirror = (function() {
     "Left": "goCharLeft", "Right": "goCharRight", "Up": "goLineUp", "Down": "goLineDown",
     "End": "goLineEnd", "Home": "goLineStartSmart", "PageUp": "goPageUp", "PageDown": "goPageDown",
     "Delete": "delCharAfter", "Backspace": "delCharBefore", "Shift-Backspace": "delCharBefore",
-    "Tab": "defaultTab", "Shift-Tab": "indentAuto",
+    "Tab": "indentMore", "Shift-Tab": "indentLess",
     "Enter": "newlineAndIndent", "Insert": "toggleOverwrite"
   };
   // Note that the save and find-related commands aren't defined by


### PR DESCRIPTION
Previous settings cause inconsistent behaviour(atleast to me)
[Tab]defaultTab - If something is selected, indent it by one indent unit. If nothing is selected, insert a tab character
[Shift-Tab]indentAuto - Auto-indent the current line or selection

[https://codemirror.net/5/doc/manual.html](https://codemirror.net/5/doc/manual.html)