### PR TITLE
module re instead of library

### DIFF
--- a/book3/11-regex.mkd
+++ b/book3/11-regex.mkd
@@ -12,7 +12,7 @@ using lists and string slicing to extract portions of the lines.
 \index{re module}
 
 This task of searching and extracting is so common that Python has a
-very powerful library called *regular expressions* that
+very powerful module called *regular expressions* that
 handles many of these tasks quite elegantly. The reason we have not
 introduced regular expressions earlier in the book is because while they
 are very powerful, they are a little complicated and their syntax takes
@@ -28,9 +28,9 @@ regular expressions, see:
 
 <https://docs.python.org/library/re.html>
 
-The regular expression library `re` must be imported into
+The regular expression module `re` must be imported into
 your program before you can use it. The simplest use of the regular
-expression library is the `search()` function. The following
+expression module is the `search()` function. The following
 program demonstrates a trivial use of the search function.
 
 \index{regex!search}
@@ -66,7 +66,7 @@ lines where "From:" was at the beginning of the line as follows:
 Now we will only match lines that *start with* the string
 "From:". This is still a very simple example that we could have done
 equivalently with the `startswith()` method from the string
-library. But it serves to introduce the notion that regular expressions
+module. But it serves to introduce the notion that regular expressions
 contain special action characters that give us more control as to what
 will match the regular expression.
 
@@ -403,7 +403,7 @@ When we run the program, we get the following output:
 Remember that the `[0-9]+` is "greedy" and it tries to make as large a
 string of digits as possible before extracting those digits. This
 "greedy" behavior is why we get all five digits for each number. The
-regular expression library expands in both directions until it
+regular expression module expands in both directions until it
 encounters a non-digit, or the beginning or the end of a line.
 
 Now we can use regular expressions to redo an exercise from earlier in


### PR DESCRIPTION
According to:
https://docs.python.org/3/library/re.html
https://github.com/python/cpython/blob/3.10/Lib/re.py

a library typically contains multiple modules so "re" should, more correctly, be referred to as module I think