### PR TITLE
Update 09-dictionaries.mkd

### DIFF
--- a/book3/09-dictionaries.mkd
+++ b/book3/09-dictionaries.mkd
@@ -400,8 +400,8 @@ Here's what the output looks like:
 
 ~~~~
 ['chuck', 'annie', 'jan']
-chuck 1
 annie 42
+chuck 1
 jan 100
 ~~~~
 


### PR DESCRIPTION
output of sorted chuck, annie, jan example was not in alphabetical order as intended by the surrounding text and the associated code.

moved chuck from position 1 to position 2 to properly demonstrate the alphabetical sorting of a dictionary when used with the sort() method.