### PR TITLE
Raw string prefix to allow backslash in RegEx

### DIFF
--- a/code3/re05.py
+++ b/code3/re05.py
@@ -1,4 +1,4 @@
 import re
 s = 'A message from csev@umich.edu to cwen@iupui.edu about meeting @2PM'
-lst = re.findall('\S+@\S+', s)
+lst = re.findall(r'\S+@\S+', s)
 print(lst)

--- a/code3/re06.py
+++ b/code3/re06.py
@@ -3,6 +3,6 @@ import re
 hand = open('mbox-short.txt')
 for line in hand:
     line = line.rstrip()
-    x = re.findall('\S+@\S+', line)
+    x = re.findall(r'\S+@\S+', line)
     if len(x) > 0:
         print(x)

--- a/code3/re07.py
+++ b/code3/re07.py
@@ -4,6 +4,6 @@ import re
 hand = open('mbox-short.txt')
 for line in hand:
     line = line.rstrip()
-    x = re.findall('[a-zA-Z0-9]\S*@\S*[a-zA-Z]', line)
+    x = re.findall(r'[a-zA-Z0-9]\S*@\S*[a-zA-Z]', line)
     if len(x) > 0:
         print(x)

--- a/code3/re08.py
+++ b/code3/re08.py
@@ -5,6 +5,6 @@ import re
 hand = open('mbox-short.txt')
 for line in hand:
     line = line.rstrip()
-    x = re.findall('[a-zA-Z0-9\-.]\S+@[a-zA-Z0-9].\S+[a-zA-Z]', line)
+    x = re.findall(r'[a-zA-Z0-9\-.]\S+@[a-zA-Z0-9].\S+[a-zA-Z]', line)
     if len(x) > 0:
         print(x)

--- a/code3/re09.py
+++ b/code3/re09.py
@@ -5,6 +5,6 @@ import re
 hand = open('mbox-short.txt')
 for line in hand:
     line = line.rstrip()
-    x = re.findall('^X\S*: (\S+)', line)
+    x = re.findall(r'^X\S*: (\S+)', line)
     if not x: continue
     print(x)

--- a/code3/re10.py
+++ b/code3/re10.py
@@ -6,5 +6,5 @@ import re
 hand = open('mbox-short.txt')
 for line in hand:
     line = line.rstrip()
-    if re.search('^X\S*: [0-9.]+', line):
+    if re.search(r'^X\S*: [0-9.]+', line):
         print(line)

--- a/code3/re11.py
+++ b/code3/re11.py
@@ -6,6 +6,6 @@ import re
 hand = open('mbox-short.txt')
 for line in hand:
     line = line.rstrip()
-    x = re.findall('^X\S*: ([0-9.]+)', line)
+    x = re.findall(r'^X\S*: ([0-9.]+)', line)
     if len(x) > 0:
         print(x)


### PR DESCRIPTION
Fixes a minor typo in the regex: in modern Python, backslashes are treated specially; this behavior can be disabled by prefixing strings with r.