### PR TITLE
Update urllinks.py, comments only

### DIFF
--- a/code3/urllinks.py
+++ b/code3/urllinks.py
@@ -1,12 +1,13 @@
 # To run this, download the BeautifulSoup zip file
 # http://www.py4e.com/code3/bs4.zip
+# or pip install beautifulsoup4 to ensure you have the latest version
 # and unzip it in the same directory as this file
 
 import urllib.request, urllib.parse, urllib.error
 from bs4 import BeautifulSoup
-import ssl
+import ssl # defauts to certicate verification and most secure protocol (now TLS)
 
-# Ignore SSL certificate errors
+# Ignore SSL/TLS certificate errors
 ctx = ssl.create_default_context()
 ctx.check_hostname = False
 ctx.verify_mode = ssl.CERT_NONE


### PR DESCRIPTION
We know SSL is deprecated in favor of TLS. Although the package is still named SSL and many companies still call their certs SSL certificates, I think it's useful to surface this so people learning about security are aware of the shift, not confused by "SSL", and comfortable using the SSL package. 

Also Python developers should become aware of the normal pip install mechanism, which takes advantage of the latest version and encourages better security practices.

All this is subtle...but for the student in the far corner of the world learning Python and trying to learn from the information in front of them...perhaps this can help a tiny bit. 