### PR TITLE
Updated spider.py: moved BeautifulSoup html.parser to fix "cannot retrieve or parse page" error

### DIFF
--- a/code3/pagerank/spider.py
+++ b/code3/pagerank/spider.py
@@ -77,6 +77,8 @@ while True:
         document = urlopen(url, context=ctx)
 
         html = document.read()
+	soup = BeautifulSoup(html, "html.parser")
+
         if document.getcode() != 200 :
             print("Error on page: ",document.getcode())
             cur.execute('UPDATE Pages SET error=? WHERE url=?', (document.getcode(), url) )
@@ -86,10 +88,9 @@ while True:
             cur.execute('DELETE FROM Pages WHERE url=?', ( url, ) )
             conn.commit()
             continue
-
+		
         print('('+str(len(html))+')', end=' ')
 
-        soup = BeautifulSoup(html, "html.parser")
     except KeyboardInterrupt:
         print('')
         print('Program interrupted by user...')


### PR DESCRIPTION
Moved 
' soup = BeautifulSoup(html, "html.parser") '
from line 92 to line 80. 

I was getting parsing errors every time I attempted to run it. Moving it above the if statements in the try finally got it running smoothly.  I saw many people online with the same issues/error attempting to run this code so they could follow along with the Page Rank worked example.

Hope this isn't too wordy, it's my very first pull request.