### PR TITLE
Minor clarifications for chapters 10 and 12

### DIFF
--- a/book3/10-tuples.mkd
+++ b/book3/10-tuples.mkd
@@ -358,7 +358,7 @@ key:
 [('a', 10), ('b', 1), ('c', 22)]
 ~~~~
 
-The new list is sorted in ascending alphabetical order by the key value.
+The list of tuples is now sorted in ascending alphabetical order by the key.
 
 Multiple assignment with dictionaries
 -------------------------------------
@@ -403,7 +403,7 @@ To do this, we first make a list of tuples where each tuple is
 list of `(key, value)` tuples, but this time we want to sort
 by value, not key. Once we have constructed the list with the value-key
 tuples, it is a simple matter to sort the list in reverse order and
-print out the new, sorted list.
+print it out.
 
 ~~~~ {.python}
 >>> d = {'a':10, 'b':1, 'c':22}
@@ -420,7 +420,7 @@ print out the new, sorted list.
 ~~~~
 
 By carefully constructing the list of tuples to have the value as the
-first element of each tuple, we can sort the list of tuples and get our
+first element of each tuple, we can sort the list of tuples and print our
 dictionary contents sorted by value.
 
 The most common words

--- a/book3/12-network.mkd
+++ b/book3/12-network.mkd
@@ -119,7 +119,8 @@ send and receive the data according to the protocol.
 
 However, since the protocol that we use most commonly is the HTTP web
 protocol, Python has a special library specifically designed to support
-the HTTP protocol for the retrieval of documents and data over the web.
+the HTTP protocol for the retrieval of documents and data over the web,
+`urllib`, which we'll cover shortly.
 
 One of the requirements for using the HTTP protocol is the need to send
 and receive data as bytes objects, instead of strings. In the preceding


### PR DESCRIPTION
Proposing two minor edits to the book to improve clarity:

- Chapter 10: Clarifies that the `sort()` method operates in-place and does not return a new list.
- Chapter 12: Adds a reference to `urllib` as the HTTP-focused library, to distinguish it from `socket` mentioned earlier in the chapter.

Changes are intended to help avoid small but common points of confusion for new learners.